### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ wpb-bot
 
 ### praw.ini file
 
-You'll need a `praw.ini` file in the '/src' folder of this repo. Copy over the `praw.ini.example` file and fill in the details. You'll need to get the client_id and client_secret from the Reddit application
+You'll need a `praw.ini` file in the '/src' folder of this repo. Copy over the `praw.ini.example` file and fill in the details. You'll need to get the client_id and client_secret from the owners of the project.
 
 ### Option 1: the virtualenv way
 


### PR DESCRIPTION
Changed where to get Reddit client secret info. Users can't get it from Reddit without creating their own bot. They have to get this info from those of us that have the login creds for each account.

We need a way to emulate PRAW for local development, or disable it in --dev env so everything still works, but praw.ini isn't needed.

Perhaps a config for a --contributor env is needed that runs --skip-tracking and --simulate-replies by default for development and testing branches before committing and submitting PRs.