### PR TITLE
Allow show me the plans within larger context

### DIFF
--- a/src/matching.py
+++ b/src/matching.py
@@ -256,7 +256,7 @@ class RuleStrategy:
         """
         Matches strictly to a request at the end of the post for the full list of all known plans
         """
-        if re.search(r"show me the plans\W*\Z", post.text, re.IGNORECASE):
+        if re.search(r"show me the plans\W*$", post.text, re.IGNORECASE | re.MULTILINE):
             return {"operation": "all_the_plans"}
 
     @staticmethod

--- a/src/matching_test.py
+++ b/src/matching_test.py
@@ -1,0 +1,64 @@
+import pytest
+
+from matching import RuleStrategy
+
+
+class MockComment:
+    def __init__(self):
+        self.text = "text of comment"
+
+
+def mock_comment(text):
+    comment = MockComment()
+    comment.text = text
+    return comment
+
+
+class TestRuleStrategy:
+    show_me_the_plans_operation = {"operation": "all_the_plans"}
+
+    def test_show_me_the_plans(self):
+        assert (
+            RuleStrategy.request_plan_list(
+                [], mock_comment("!WarrenPlanBot show me the plans")
+            )
+            == self.show_me_the_plans_operation
+        )
+
+        assert (
+            RuleStrategy.request_plan_list(
+                [],
+                mock_comment(
+                    "!WarrenPlanBot show me the plans\n\nI want to show the world the plans"
+                ),
+            )
+            == self.show_me_the_plans_operation
+        )
+
+        assert (
+            RuleStrategy.request_plan_list(
+                [],
+                mock_comment(
+                    "I love to show people the plans\n!WarrenPlanBot show me the plans\n\nI want to show the world the plans"
+                ),
+            )
+            == self.show_me_the_plans_operation
+        )
+
+        assert (
+            RuleStrategy.request_plan_list(
+                [],
+                mock_comment(
+                    "!WarrenPlanBot\n\nYou know I love you now show me the plans"
+                ),
+            )
+            == self.show_me_the_plans_operation
+        )
+
+        assert (
+            RuleStrategy.request_plan_list(
+                [],
+                mock_comment("!WarrenPlanBot show me the plans about something I love"),
+            )
+            is None
+        )


### PR DESCRIPTION
This allows for "show me the plan" at the end of any line, even if it's not the very end of the post

Folks seem to want to use it that way :)
 https://www.reddit.com/r/ElizabethWarren/comments/d4v6x9/can_someone_please_highlight_briefly_the/f0gxqm9/

Looks like this person had to do some editing of their post to make it show up how they wanted it!