### PR TITLE
Add support for parent flag

### DIFF
--- a/src/matching_test.py
+++ b/src/matching_test.py
@@ -1,7 +1,6 @@
 import pytest
 
-from matching import RuleStrategy, get_trigger_line
-
+from matching import RuleStrategy
 
 class MockComment:
     def __init__(self):
@@ -17,11 +16,19 @@ def mock_comment(text):
 class TestRuleStrategy:
     show_me_the_plans_operation = {"operation": "all_the_plans"}
     help_operation = {"operation": "help"}
+    advanced_help_operation = {"operation": "advanced_help"}
 
     def test_show_me_the_plans(self):
         assert (
             RuleStrategy.request_plan_list(
-                [], mock_comment("!WarrenPlanBot show me the plans")
+                [], "show me the plans"
+            )
+            == self.show_me_the_plans_operation
+        )
+
+        assert (
+            RuleStrategy.request_plan_list(
+                [], "show me the plans\n\nI want to show the world the plans",
             )
             == self.show_me_the_plans_operation
         )
@@ -29,9 +36,7 @@ class TestRuleStrategy:
         assert (
             RuleStrategy.request_plan_list(
                 [],
-                mock_comment(
-                    "!WarrenPlanBot show me the plans\n\nI want to show the world the plans"
-                ),
+                "show me the plans\n\nI want to show the world the plans",
             )
             == self.show_me_the_plans_operation
         )
@@ -39,9 +44,7 @@ class TestRuleStrategy:
         assert (
             RuleStrategy.request_plan_list(
                 [],
-                mock_comment(
-                    "I love to show people the plans\n!WarrenPlanBot show me the plans\n\nI want to show the world the plans"
-                ),
+                "You know I love you now show me the plans",
             )
             == self.show_me_the_plans_operation
         )
@@ -49,9 +52,7 @@ class TestRuleStrategy:
         assert (
             RuleStrategy.request_plan_list(
                 [],
-                mock_comment(
-                    "!WarrenPlanBot\n\nYou know I love you now show me the plans"
-                ),
+                "show me the plans\n\nE: It looks like /u/WarrenPlanBot is offline",
             )
             == self.show_me_the_plans_operation
         )
@@ -59,62 +60,47 @@ class TestRuleStrategy:
         assert (
             RuleStrategy.request_plan_list(
                 [],
-                mock_comment(
-                    "Welcome! Warren has won me over simply because her policies are concrete.\n\n!WarrenPlanBot show me the plans\n\nE: It looks like /u/WarrenPlanBot is offline"
-                ),
-            )
-            == self.show_me_the_plans_operation
-        )
-
-        assert (
-            RuleStrategy.request_plan_list(
-                [],
-                mock_comment("!WarrenPlanBot show me the plans about something I love"),
+                "show me the plans about something I love",
             )
             is None
         )
 
     def test_help(self):
         assert (
-            RuleStrategy.request_help([], mock_comment("!WarrenPlanBot help"))
+            RuleStrategy.request_help([], "help")
             == self.help_operation
         )
 
         assert (
             RuleStrategy.request_help(
-                [], mock_comment("blah blah\n!WarrenPlanBot help\nthanks in advance")
+                [], "help\nthanks in advance"
             )
             == self.help_operation
         )
 
         assert (
             RuleStrategy.request_help(
-                [], mock_comment("!WarrenPlanBot show me the plans")
+                [], "show me the plans"
             )
             is None
         )
 
-
-def test_get_trigger_line():
-    assert (
-        get_trigger_line(
-            "i love liz warren\n!WarrenPlAnBot do you love Liz too?\ntell me the truth"
+    def test_advanced_help(self):
+        assert (
+            RuleStrategy.request_help([], "advanced help")
+            == self.advanced_help_operation
         )
-        == "do you love Liz too?"
-    )
 
-    assert (
-        get_trigger_line(
-            "I like it here\n!WarrenPlAnBot do you?\n!WarrenPlAnBot do you really?"
+        assert (
+            RuleStrategy.request_help(
+                [], "advanced help\nthanks in advance"
+            )
+            == self.advanced_help_operation
         )
-        == "do you really?"
-    )
 
-    assert get_trigger_line("!WarrenPlanBot, what's up?") == "what's up?"
-    assert get_trigger_line("!WarrenPlanBot,what's good?") == "what's good?"
-    assert (
-        get_trigger_line(
-            "/u/WarrenPlanBot hi\n!WarrenPlanBot,what's good?\n/u/WarrenPlanBot hi\nwarrenplanbot ho"
+        assert (
+            RuleStrategy.request_help(
+                [], "advanced show me the plans"
+            )
+            is None
         )
-        == "what's good?"
-    )

--- a/src/plan_bot.py
+++ b/src/plan_bot.py
@@ -352,7 +352,7 @@ def get_trigger_line(text, trigger_word="!warrenplanbot"):
     Get the last line that !WarrenPlanBot occurs on,
     only returning the part of that line which occurs _after_ !WarrenPlamBot
     """
-    matches = re.findall(fr"{trigger_word}\W+(.*)$", text, re.IGNORECASE | re.MULTILINE)
+    matches = re.findall(fr"{trigger_word}[^-\w]+(.*)$", text, re.IGNORECASE | re.MULTILINE)
 
     return matches[-1] if matches else ""
 
@@ -366,7 +366,7 @@ def process_flags(text):
         "parent": False
     }
 
-    match = re.match(r"^(?:-p|--parent)\s+(.*)$", text, re.IGNORECASE | re.MULTILINE)
+    match = re.match(r"^(?:-p|--parent)[^-\w]+(.*)$", text, re.IGNORECASE | re.MULTILINE)
     if match:
         options["parent"] = True
         text = match.group(1)

--- a/src/plan_bot_test.py
+++ b/src/plan_bot_test.py
@@ -189,11 +189,12 @@ def test_build_response_text_to_all_the_plans_operation(
 @mock.patch("plan_bot.build_response_text", return_value="response text")
 @mock.patch("plan_bot.reply")
 @pytest.mark.parametrize(
-    ["post_text", "expected_matching_plan"],
+    ["post_text", "expected_matching_plan", "is_parent"],
     [
-        ("!WarrenPlanBot A Title for the 21st Century", PLANS[0]),
-        ("!WarrenPlanBot Another Title To Really Make a Person Think", PLANS[1]),
-        ("!WarrenPlanBot  another title to really make a Person Think   ", PLANS[1]),
+        ("!WarrenPlanBot A Title for the 21st Century", PLANS[0], False),
+        ("!WarrenPlanBot Another Title To Really Make a Person Think", PLANS[1], False),
+        ("!WarrenPlanBot  another title to really make a Person Think   ", PLANS[1], False),
+        ("!WarrenPlanBot --parent another title to really make a Person Think   ", PLANS[1], True),
     ],
 )
 def test_process_post_matches_by_display_title(
@@ -202,6 +203,7 @@ def test_process_post_matches_by_display_title(
     mock_create_db_record,
     post_text,
     expected_matching_plan,
+    is_parent
 ):
     post = MockSubmission(post_text)
 
@@ -209,7 +211,7 @@ def test_process_post_matches_by_display_title(
 
     mock_build_response_text.assert_called_once_with(expected_matching_plan, post)
     mock_reply.assert_called_once_with(
-        post, "response text", send=False, simulate=False
+        post, "response text", send=False, simulate=False, parent=is_parent
     )
 
 
@@ -253,7 +255,7 @@ def test_process_post_matches_real_plan(
 
     mock_build_response_text.assert_called_once_with(plans[0], post)
     mock_reply.assert_called_once_with(
-        post, "some response text", send=False, simulate=False
+        post, "some response text", send=False, simulate=False, parent=False
     )
 
 
@@ -285,3 +287,46 @@ def test_process_post_wont_reply_to_warren_plan_bot(
 
     mock_build_response_text.assert_not_called()
     mock_reply.assert_not_called()
+
+def test_get_trigger_line():
+    assert (
+        plan_bot.get_trigger_line(
+            "i love liz warren\n!WarrenPlAnBot do you love Liz too?\ntell me the truth"
+        )
+        == "do you love Liz too?"
+    )
+
+    assert (
+        plan_bot.get_trigger_line(
+            "I like it here\n!WarrenPlAnBot do you?\n!WarrenPlAnBot do you really?"
+        )
+        == "do you really?"
+    )
+
+    assert plan_bot.get_trigger_line("!WarrenPlanBot, what's up?") == "what's up?"
+    assert plan_bot.get_trigger_line("!WarrenPlanBot,what's good?") == "what's good?"
+    assert (
+        plan_bot.get_trigger_line(
+            "/u/WarrenPlanBot hi\n!WarrenPlanBot,what's good?\n/u/WarrenPlanBot hi\nwarrenplanbot ho"
+        )
+        == "what's good?"
+    )
+
+    assert plan_bot.get_trigger_line("!WarrenPlanBot, --parent what's up?") == "--parent what's up?"
+    assert plan_bot.get_trigger_line("!WarrenPlanBot,--parent what's up?") == "--parent what's up?"
+
+def test_process_flags():
+    assert (
+        plan_bot.process_flags("what's up")
+        == ("what's up", {"parent": False})
+    )
+
+    assert (
+        plan_bot.process_flags("--parent what's up")
+        == ("what's up", {"parent": True})
+    )
+
+    assert (
+        plan_bot.process_flags("--parent, what's up")
+        == ("what's up", {"parent": True})
+    )


### PR DESCRIPTION
Adds support for the `--parent` or `-p` flag in the message to the bot to send the reply to the parent of the comment instead the triggering comment itself.

Refactors the `process_post` function and `Strategy` classes so that the parent flag is identified and removed from the text that is then passed on to the `Strategy` classes for plan identification/help.

Adds an `advanced help` rule that returns information about the parent flag. I don't feel super strongly about this so I'm happy to put the info about the parent flag in the main help if desired.

## Related issue
https://github.com/techforwarren/warren-plan-bot/issues/82

