### PR TITLE
Updates to parent flag

### DIFF
--- a/scripts/score_strategies.py
+++ b/scripts/score_strategies.py
@@ -6,6 +6,7 @@ from os import path
 import click
 
 from matching import Strategy
+import plan_bot
 
 DIRNAME = path.dirname(path.realpath(__file__))
 
@@ -57,7 +58,8 @@ def score_strategy(strategy):
     strategy_name = strategy.__name__
     match_scoring = []
     for post in labeled_posts:
-        match_info = strategy(plans, post)
+        post_text, _ = plan_bot.process_flags(plan_bot.get_trigger_line(post.text))
+        match_info = strategy(plans, post_test, post=post)
         match = {
             "post_text": post.text,
             "post_source": post.source,

--- a/scripts/score_strategies.py
+++ b/scripts/score_strategies.py
@@ -59,7 +59,7 @@ def score_strategy(strategy):
     match_scoring = []
     for post in labeled_posts:
         post_text, _ = plan_bot.process_flags(plan_bot.get_trigger_line(post.text))
-        match_info = strategy(plans, post_test, post=post)
+        match_info = strategy(plans, post_text, post=post)
         match = {
             "post_text": post.text,
             "post_source": post.source,

--- a/src/plan_bot.py
+++ b/src/plan_bot.py
@@ -144,8 +144,8 @@ Have another question or run into any problems?  [Send a report](https://www.red
 def build_advanced_response_text(plans, post):
     return """I’m the WarrenPlanBot. If Elizabeth Warren has a plan, I can help you find it!
 
-If you start your message with `-p` or `--parent` like this:
-`!WarrenPlanBot --parent [plan_topic]`,
+If you start your message with `--tell-parent` like this:
+`!WarrenPlanBot --tell-parent [plan_topic]`,
 I'll reply directly to the parent message.
 
 To see my full list of Elizabeth’s plans, you can use the command: `!WarrenPlanBot show me the plans`
@@ -285,7 +285,7 @@ def process_post(
         post_record_update["reply_type"] = "no_match"
 
     try:
-        did_reply = reply(post, reply_string, send=send, simulate=simulate, parent=options["parent"])
+        did_reply = reply(post, reply_string, parent=options["parent"], send=send, simulate=simulate)
     except APIException as e:
         if e.error_type == "DELETED_COMMENT":
             did_reply = False
@@ -366,7 +366,7 @@ def process_flags(text):
         "parent": False
     }
 
-    match = re.match(r"^(?:-p|--parent)[^-\w]+(.*)$", text, re.IGNORECASE | re.MULTILINE)
+    match = re.match(r"^(?:--tell-parent)[^-\w]+(.*)$", text, re.IGNORECASE | re.MULTILINE)
     if match:
         options["parent"] = True
         text = match.group(1)

--- a/src/plan_bot.py
+++ b/src/plan_bot.py
@@ -144,8 +144,8 @@ Have another question or run into any problems?  [Send a report](https://www.red
 def build_advanced_response_text(plans, post):
     return """I’m the WarrenPlanBot. If Elizabeth Warren has a plan, I can help you find it!
 
-If you start your message with `--tell-parent` like this:
-`!WarrenPlanBot --tell-parent [plan_topic]`,
+If you start your message with `--tell-parent` or `--parent` like this:
+`!WarrenPlanBot --tell-parent [plan_topic]` OR `!WarrenPlanBot --parent [plan_topic]`,
 I'll reply directly to the parent message.
 
 To see my full list of Elizabeth’s plans, you can use the command: `!WarrenPlanBot show me the plans`
@@ -366,7 +366,7 @@ def process_flags(text):
         "parent": False
     }
 
-    match = re.match(r"^(?:--tell-parent)[^-\w]+(.*)$", text, re.IGNORECASE | re.MULTILINE)
+    match = re.match(r"^(?:--parent|--tell-parent)[^-\w]+(.*)$", text, re.IGNORECASE | re.MULTILINE)
     if match:
         options["parent"] = True
         text = match.group(1)

--- a/src/plan_bot_test.py
+++ b/src/plan_bot_test.py
@@ -194,7 +194,7 @@ def test_build_response_text_to_all_the_plans_operation(
         ("!WarrenPlanBot A Title for the 21st Century", PLANS[0], False),
         ("!WarrenPlanBot Another Title To Really Make a Person Think", PLANS[1], False),
         ("!WarrenPlanBot  another title to really make a Person Think   ", PLANS[1], False),
-        ("!WarrenPlanBot --parent another title to really make a Person Think   ", PLANS[1], True),
+        ("!WarrenPlanBot --tell-parent another title to really make a Person Think   ", PLANS[1], True),
     ],
 )
 def test_process_post_matches_by_display_title(
@@ -312,8 +312,8 @@ def test_get_trigger_line():
         == "what's good?"
     )
 
-    assert plan_bot.get_trigger_line("!WarrenPlanBot, --parent what's up?") == "--parent what's up?"
-    assert plan_bot.get_trigger_line("!WarrenPlanBot,--parent what's up?") == "--parent what's up?"
+    assert plan_bot.get_trigger_line("!WarrenPlanBot, --tell-parent what's up?") == "--tell-parent what's up?"
+    assert plan_bot.get_trigger_line("!WarrenPlanBot,--tell-parent what's up?") == "--tell-parent what's up?"
 
 def test_process_flags():
     assert (
@@ -322,11 +322,11 @@ def test_process_flags():
     )
 
     assert (
-        plan_bot.process_flags("--parent what's up")
+        plan_bot.process_flags("--tell-parent what's up")
         == ("what's up", {"parent": True})
     )
 
     assert (
-        plan_bot.process_flags("--parent, what's up")
+        plan_bot.process_flags("--tell-parent, what's up")
         == ("what's up", {"parent": True})
     )

--- a/src/plan_bot_test.py
+++ b/src/plan_bot_test.py
@@ -327,6 +327,21 @@ def test_process_flags():
     )
 
     assert (
+        plan_bot.process_flags("--parent what's up")
+        == ("what's up", {"parent": True})
+    )
+
+    assert (
+        plan_bot.process_flags("-parent what's up")
+        == ("-parent what's up", {"parent": False})
+    )
+
+    assert (
+        plan_bot.process_flags("--parnet what's up")
+        == ("--parnet what's up", {"parent": False})
+    )
+
+    assert (
         plan_bot.process_flags("--tell-parent, what's up")
         == ("what's up", {"parent": True})
     )


### PR DESCRIPTION
- Removes `-p` option
- Renames to `--tell-parent`
- Update `score_strategies.py` to use new `Strategy` contract 

Addresses:
https://github.com/techforwarren/warren-plan-bot/issues/146
https://github.com/techforwarren/warren-plan-bot/issues/147
