### PR TITLE
Use subreddit comments api to additionally check for all recent comments

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -146,6 +146,16 @@ def run_plan_bot(
         if not comments_progress.exists:
             comments_progress = None
 
+    process_the_post = lambda post: process_post(
+        post,
+        plans,
+        posts_db,
+        post_ids_processed,
+        send=send_replies,
+        simulate=simulate_replies,
+        skip_tracking=skip_tracking,
+    )
+
     subreddit_name = "ElizabethWarren" if praw_site == "prod" else "WPBSandbox"
 
     # Get the subreddit
@@ -158,15 +168,7 @@ def run_plan_bot(
     ):
         # turn this into our more standardized class
         submission = reddit_util.Submission(submission)
-        process_post(
-            submission,
-            plans,
-            posts_db,
-            post_ids_processed,
-            send=send_replies,
-            simulate=simulate_replies,
-            skip_tracking=skip_tracking,
-        )
+        process_the_post(submission)
 
     for pushshift_comment in pushshift.search_comments(
         "warrenplanbot", subreddit_name, limit=limit
@@ -176,15 +178,7 @@ def run_plan_bot(
             praw.models.Comment(reddit, _data=pushshift_comment)
         )
 
-        process_post(
-            comment,
-            plans,
-            posts_db,
-            post_ids_processed,
-            send=send_replies,
-            simulate=simulate_replies,
-            skip_tracking=skip_tracking,
-        )
+        process_the_post(comment)
 
     # Get new comments since we last ran.
     #
@@ -198,15 +192,7 @@ def run_plan_bot(
     for comment in subreddit.comments(params=comment_params):
         comment = reddit_util.Comment(comment)
         if re.search("warrenplanbot", comment.text, re.IGNORECASE):
-            process_post(
-                comment,
-                plans,
-                posts_db,
-                post_ids_processed,
-                send=send_replies,
-                simulate=simulate_replies,
-                skip_tracking=skip_tracking,
-            )
+            process_the_post(comment)
 
         # update the cursor after processing the comment
         if not current_newest_comment_id:

--- a/src/main.py
+++ b/src/main.py
@@ -215,6 +215,7 @@ def get_comments_params(comments_progress_ref):
     # comments in the subreddit.
     return {}
 
+
 def run_plan_bot_event_handler(event, context):
     start_time = time.time()
     print("Starting plan bot loop")

--- a/src/main.py
+++ b/src/main.py
@@ -192,12 +192,7 @@ def run_plan_bot(
     # need to keep track of that and save that as our cursor.  With no
     # specified params, it returns newest 100 comments in the
     # subreddit.
-    comments_params = {}
-    if comments_progress:
-        newest_comment_id = comments_progress.get("newest")
-        if newest_comment_id:
-            # Gets newer comments that our newest comment
-            comments_params["before"] = newest_comment_id
+    comments_params = get_comments_params(comments_progress)
 
     current_newest_comment_id = None
     for comment in subreddit.comments(params=comment_params):
@@ -224,6 +219,17 @@ def run_plan_bot(
 
     print(f"Single pass of plan bot took: {round(time.time() - pass_start_time, 2)}s")
 
+
+def get_comments_params(comments_progress):
+    if comments_progress:
+        newest_comment_id = comments_progress.get("newest")
+        if newest_comment_id:
+            # Gets newer comments that our newest comment
+            return {"before": newest_comment_id}
+
+    # Empty params causes subreddit.comments() to return the newest
+    # comments in the subreddit.
+    return {}
 
 def run_plan_bot_event_handler(event, context):
     start_time = time.time()

--- a/src/main.py
+++ b/src/main.py
@@ -180,24 +180,18 @@ def run_plan_bot(
     # Get new comments since we last ran.
     #
     # subreddit.comments() returns the newest comments first so we
-    # need to keep track of that and save that as our cursor.  With no
-    # specified params, it returns newest 100 comments in the
+    # need to reverse it so that the comments we're iterating over are getting newer.
+    # With no specified params, it returns newest 100 comments in the
     # subreddit.
     comments_params = get_comments_params(comments_progress_ref)
-
-    current_newest_comment_id = None
-    for comment in subreddit.comments(params=comments_params):
+    for comment in reversed(list(subreddit.comments(params=comments_params))):
         comment = reddit_util.Comment(comment)
         if re.search("warrenplanbot", comment.text, re.IGNORECASE):
             process_the_post(comment)
 
         # update the cursor after processing the comment
-        if not current_newest_comment_id:
-            current_newest_comment_id = comment.fullname
-            if not skip_tracking:
-                comments_progress_ref.set(
-                    {"newest": current_newest_comment_id}, merge=True
-                )
+        if not skip_tracking:
+            comments_progress_ref.set({"newest": comment.fullname}, merge=True)
 
     print(f"Single pass of plan bot took: {round(time.time() - pass_start_time, 2)}s")
 

--- a/src/plan_bot.py
+++ b/src/plan_bot.py
@@ -198,13 +198,16 @@ def process_post(
     matching_strategy=Strategy.lsa_gensim_v3,
 ):
     if post_ids_processed is None:
-        post_ids_processed = {}
-
-    print(f"Processing post {post.type}: {post.id}")
+        post_ids_processed = set()
 
     # Make sure we don't reply to a post we've already processed
     if post.id in post_ids_processed:
         return
+
+    print(f"Processing post {post.type}: {post.id}")
+
+    # Add this post to the set of processed posts
+    post_ids_processed.add(post.id)
 
     # Never try to reply if a post is locked
     if post.locked:


### PR DESCRIPTION
Creates a new collection in firestore for tracking the progress of
comment processing so that we eventually only check the latest comments

This is a first pass at solving #135. Uses the [`comments`](https://praw.readthedocs.io/en/latest/code_overview/models/subreddit.html#praw.models.Subreddit.comments) api to get the latest comments (by default fetches limits to 100) of the subreddit. And tracks the earliest and latest comments it found. Subsequent runs uses these "cursors" to fetch any newer and older comments.

