### PR TITLE
Reduce firestore reads

### DIFF
--- a/migrations/posts_replied_2.py
+++ b/migrations/posts_replied_2.py
@@ -1,0 +1,46 @@
+import click
+from google.cloud import firestore
+
+
+@click.command()
+@click.option(
+    "--project",
+    envvar="GCP_PROJECT",
+    default="wpb-dev",
+    type=str,
+    help="gcp project where firestore db lives",
+)
+@click.option(
+    "--dry-run",
+    default=False,
+    is_flag=True,
+    help="run a dry run before executing the migration",
+)
+def run_migration(project="wpb-dev", dry_run=False):
+
+    db = firestore.Client(project=project)
+
+    posts_db = db.collection("posts")
+
+    for post in posts_db.where("replied", "==", True).stream():
+        post_id = post.id
+        post = post.to_dict()
+        post_record_update = {}
+        if not post.get("processed"):
+            post_record_update["processed"] = True
+
+        if post_record_update:
+            if dry_run:
+                print(
+                    f"[dry-run] For post: {post_id}\n[dry-run] With content:{post}\n[dry-run] Would update {post_record_update}"
+                )
+            else:
+                print(
+                    f"For post: {post_id}\n[dry-run] With content:{post}\n[dry-run] Updating {post_record_update}"
+                )
+                # partial update of record
+                posts_db.document(post_id).update(post_record_update)
+
+
+if __name__ == "__main__":
+    run_migration()

--- a/src/main.py
+++ b/src/main.py
@@ -24,6 +24,8 @@ TIME_IN_LOOP = os.getenv(
 
 click_kwargs = {"show_envvar": True, "show_default": True}
 
+POST_IDS_PROCESSED = {}
+
 
 @click.command()
 @click.option(
@@ -123,17 +125,18 @@ def run_plan_bot(
 
     if skip_tracking:
         posts_db = None
-        post_ids_processed = {}
         comments_progress_ref = None
     else:
         db = firestore.Client(project=project)
 
         posts_db = db.collection("posts")
 
-        # Load the list of posts processed to or start with empty list if none
-        posts_processed = posts_db.where("processed", "==", True).stream()
+        # get post ids from database only if we don't already have them
+        if not POST_IDS_PROCESSED:
+            # Load the list of posts processed to or start with empty list if none
+            posts_processed = posts_db.where("processed", "==", True).stream()
 
-        post_ids_processed = {post.id for post in posts_processed}
+            POST_IDS_PROCESSED.update({post.id for post in posts_processed})
 
         # Track progress of comments
         comments_progress_ref = db.collection("progress").document("comments")
@@ -142,7 +145,7 @@ def run_plan_bot(
         post,
         plans,
         posts_db,
-        post_ids_processed,
+        POST_IDS_PROCESSED,
         send=send_replies,
         simulate=simulate_replies,
         skip_tracking=skip_tracking,

--- a/src/main.py
+++ b/src/main.py
@@ -130,15 +130,10 @@ def run_plan_bot(
 
         posts_db = db.collection("posts")
 
-        # Load the list of posts replied to or start with empty list if none
-        posts_replied_to = posts_db.where("replied", "==", True).stream()
-        # TODO migrate posts replied=True to have processed=True, and remove the query above (#84)
+        # Load the list of posts processed to or start with empty list if none
         posts_processed = posts_db.where("processed", "==", True).stream()
 
-        # include processed posts in replied to
-        post_ids_processed = {post.id for post in posts_replied_to}.union(
-            {post.id for post in posts_processed}
-        )
+        post_ids_processed = {post.id for post in posts_processed}
 
         # Track progress of comments
         comments_progress_ref = db.collection("progress").document("comments")


### PR DESCRIPTION
- Migrate posts replied to be posts processed to avoid double reading some posts
- Persist posts proceesed in memory across times though the main loop to reduce reads by a factor of 15+

Closes #84 

Work towards #171 