### PR TITLE
Properly initialize POST_ID_PROCESSED as set

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -24,7 +24,7 @@ TIME_IN_LOOP = os.getenv(
 
 click_kwargs = {"show_envvar": True, "show_default": True}
 
-POST_IDS_PROCESSED = {}
+POST_IDS_PROCESSED = set()
 
 
 @click.command()


### PR DESCRIPTION
Trying to run with `--skip-tracking` failed because `POST_ID_PROCESSED` is used as a set but initialized here as a dict.